### PR TITLE
Bugfix: get_{x,y,z} should return double, not float

### DIFF
--- a/src/field.ml
+++ b/src/field.ml
@@ -54,4 +54,8 @@ module Defn = struct
   let get_type defn =
     get_type defn
     |> field_type_of_int
+
+  let get_name =
+    Lib.c "OGR_GetNameRef"
+      (t @-> returning string)
 end

--- a/src/field.mli
+++ b/src/field.mli
@@ -29,4 +29,8 @@ module Defn : sig
   val get_type : t -> field_type_t
   (** [get_type t] returns the data type associated with the field
       definition [t]. *)
+
+  val get_name : t -> string
+  (** [get_name t] returns the name associated with the field
+      definition [t]. *)
 end

--- a/src/geometry.ml
+++ b/src/geometry.ml
@@ -89,15 +89,15 @@ let get_point_count =
 
 let get_x =
   Lib.c "OGR_G_GetX"
-    (t @-> int @-> returning float)
+    (t @-> int @-> returning double)
 
 let get_y =
   Lib.c "OGR_G_GetY"
-    (t @-> int @-> returning float)
+    (t @-> int @-> returning double
 
 let get_z =
   Lib.c "OGR_G_GetZ"
-    (t @-> int @-> returning float)
+    (t @-> int @-> returning double)
 
 let clone =
   Lib.c "OGR_G_Clone"


### PR DESCRIPTION
This is a small bugfix which prevented accessing the geometry from ocaml. OGR_G_Get{X,Y,Z} return doubles, not floats, and this caused nonsensical results on the ocaml side.